### PR TITLE
run npm install while building and avoid overriding node_modules

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,9 +11,9 @@ services:
     #   context: .
     #   dockerfile: .devcontainer/Dockerfile
 
-    volumes:
+    #volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspaces:cached
+      #- ..:/workspaces:cached
 
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     # cap_add:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22
 
 WORKDIR /app
-COPY . .
+COPY package*.json /app
+RUN npm install
+COPY . /app
+CMD ["npm","run","start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
         condition: service_healthy
     volumes:
       - .:/app
+      - /app/node_modules
   db:
     image: mysql:8.0.34
     restart: always


### PR DESCRIPTION
package.json was generated, so "npm install" can be run while building container.