### PR TITLE
disable CMD in container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 COPY package*.json /app
 RUN npm install
 COPY . /app
-CMD ["npm","run","start"]
+# CMD ["npm","run","start"]


### PR DESCRIPTION
- temporary disabled `npm run start` in Dockerfile
  - as this prevents development server startup command`(docker compose exec app npm run start:dev)`